### PR TITLE
format change

### DIFF
--- a/internal/logsink/logsink.go
+++ b/internal/logsink/logsink.go
@@ -203,27 +203,27 @@ func textPrintf(m *Meta, textSinks []Text, format string, args ...any) (n int, e
 	//
 	// Avoid Fprintf, for speed. The format is so simple that we can do it quickly by hand.
 	// It's worth about 3X. Fprintf is hard.
-    severityVal:= [] string{"INFOR","WARNI","ERROR","FATAL"}
-    buf.WriteByte('[')
-    buf.WriteString(severityVal[m.Severity])
-    buf.WriteString("] ")
+	severityVal:= [] string{"INFOR","WARNI","ERROR","FATAL"}
+	buf.WriteByte('[')
+	buf.WriteString(severityVal[m.Severity])
+	buf.WriteString("] ")
 
 	year, month, day := m.Time.Date()
-    hour, minute, second := m.Time.Clock()
-    nDigits(buf,4,uint64(year),' ')
-    buf.WriteByte('-')
-    twoDigits(buf, int(month))
-    buf.WriteByte('-')
-    twoDigits(buf, day)
-    buf.WriteByte('T')
-    twoDigits(buf, hour)
-    buf.WriteByte(':')
-    twoDigits(buf, minute)
-    buf.WriteByte(':')
-    twoDigits(buf, second)
-    buf.WriteByte('.')
-    nDigits(buf, 3, uint64(m.Time.Nanosecond()/1000000), '0')
-    buf.WriteByte(' ')
+	hour, minute, second := m.Time.Clock()
+	nDigits(buf,4,uint64(year),' ')
+	buf.WriteByte('-')
+	twoDigits(buf, int(month))
+	buf.WriteByte('-')
+	twoDigits(buf, day)
+	buf.WriteByte('T')
+	twoDigits(buf, hour)
+	buf.WriteByte(':')
+	twoDigits(buf, minute)
+	buf.WriteByte(':')
+	twoDigits(buf, second)
+	buf.WriteByte('.')
+	nDigits(buf, 3, uint64(m.Time.Nanosecond()/1000000), '0')
+	buf.WriteByte(' ')
 
 	{
 		file := m.File
@@ -238,9 +238,9 @@ func textPrintf(m *Meta, textSinks []Text, format string, args ...any) (n int, e
 		var tmp [19]byte
 		buf.Write(strconv.AppendInt(tmp[:0], int64(m.Line), 10))
 	}
-    buf.WriteString(" (")
-    buf.WriteString(fmt.Sprintf("%v",m.Thread))
-    buf.WriteString(") ")
+	buf.WriteString(" (")
+	buf.WriteString(fmt.Sprintf("%v",m.Thread))
+	buf.WriteString(") ")
 
 	msgStart := buf.Len()
 	fmt.Fprintf(buf, format, args...)

--- a/internal/logsink/logsink.go
+++ b/internal/logsink/logsink.go
@@ -203,7 +203,7 @@ func textPrintf(m *Meta, textSinks []Text, format string, args ...any) (n int, e
 	//
 	// Avoid Fprintf, for speed. The format is so simple that we can do it quickly by hand.
 	// It's worth about 3X. Fprintf is hard.
-	severityVal:= [] string{"INFOR","WARNI","ERROR","FATAL"}
+	severityVal:= [] string{"INFO","WARN","ERROR","FATAL"}
 	buf.WriteByte('[')
 	buf.WriteString(severityVal[m.Severity])
 	buf.WriteString("] ")

--- a/internal/logsink/logsink.go
+++ b/internal/logsink/logsink.go
@@ -239,7 +239,7 @@ func textPrintf(m *Meta, textSinks []Text, format string, args ...any) (n int, e
 		buf.Write(strconv.AppendInt(tmp[:0], int64(m.Line), 10))
 	}
 	buf.WriteString(" (")
-	buf.WriteString(fmt.Sprintf("%v",m.Thread))
+	nDigits(buf, 7, uint64(m.Thread), ' ')
 	buf.WriteString(") ")
 
 	msgStart := buf.Len()


### PR DESCRIPTION
Description
Change log formats in golang-glog in order to standardise log format across all services for easy correlating and debugging.
Required log format: "[5_char_log_level] timestamp filename:line_number (thread_name) log message"
(timestamp format: yyyy-MM-dd'T'HH:mm:ss.SSS)

More information in [https://tetration.atlassian.net/browse/TT-2907](https://github.com/TetrationAnalytics/tetration/pull/url)