### PR TITLE
trim+pad file name and line number to keep it a consistent size

### DIFF
--- a/glog_test.go
+++ b/glog_test.go
@@ -108,7 +108,7 @@ func TestInfoDepth(t *testing.T) {
 	}
 
 	for i, m := range msgs {
-		if !strings.HasPrefix(m, "I") {
+		if !strings.HasPrefix(m, "[INFO]") {
 			t.Errorf("InfoDepth[%d] has wrong character: %q", i, m)
 		}
 		w := fmt.Sprintf("depth-test%d", i)
@@ -118,9 +118,9 @@ func TestInfoDepth(t *testing.T) {
 
 		// pull out the line number (between : and ])
 		msg := m[strings.LastIndex(m, ":")+1:]
-		x := strings.Index(msg, "]")
+		x := strings.Index(msg, " ")
 		if x < 0 {
-			t.Errorf("InfoDepth[%d]: missing ']': %q", i, m)
+			t.Errorf("InfoDepth[%d]: missing ' ': %q", i, m)
 			continue
 		}
 		line, err := strconv.Atoi(msg[:x])
@@ -178,9 +178,9 @@ func TestHeader(t *testing.T) {
 
 	Info("testHeader")
 	var line int
-	format := "I0102 15:04:05.067890 %7d glog_test.go:%d] testHeader\n"
+	format := "[INFO] 2006-01-02T15:04:05.067 glog_test.go:%d           (%7d) testHeader\n"
 	var gotPID int64
-	n, err := fmt.Sscanf(contents(logsink.Info), format, &gotPID, &line)
+	n, err := fmt.Sscanf(contents(logsink.Info), format, &line, &gotPID)
 	if n != 2 || err != nil {
 		t.Errorf("log format error: %d elements, error %s:\n%s", n, err, contents(logsink.Info))
 	}
@@ -191,7 +191,7 @@ func TestHeader(t *testing.T) {
 
 	// Scanf treats multiple spaces as equivalent to a single space,
 	// so check for correct space-padding also.
-	want := fmt.Sprintf(format, gotPID, line)
+	want := fmt.Sprintf(format, line, gotPID)
 	if contents(logsink.Info) != want {
 		t.Errorf("log format error: got:\n\t%q\nwant:\n\t%q", contents(logsink.Info), want)
 	}

--- a/internal/logsink/logsink.go
+++ b/internal/logsink/logsink.go
@@ -227,6 +227,7 @@ func textPrintf(m *Meta, textSinks []Text, format string, args ...any) (n int, e
 
 	lineNumSize := numDigits(uint64(m.Line))
 	allowedFileNameSize := maxFileNameAndLineSize - lineNumSize - 1 // -1 for colon
+	fileNameSize := 0
 
 	{
 		file := m.File
@@ -235,8 +236,10 @@ func textPrintf(m *Meta, textSinks []Text, format string, args ...any) (n int, e
 		}
 		if len(file) > allowedFileNameSize {
 			buf.WriteString(file[:allowedFileNameSize])
+			fileNameSize = allowedFileNameSize
 		} else {
 			buf.WriteString(file)
+			fileNameSize = len(file)
 		}
 	}
 
@@ -245,8 +248,8 @@ func textPrintf(m *Meta, textSinks []Text, format string, args ...any) (n int, e
 		var tmp [19]byte
 		buf.Write(strconv.AppendInt(tmp[:0], int64(m.Line), 10))
 	}
-	if len(m.File)+1+lineNumSize < maxFileNameAndLineSize {
-		buf.Write(spaces[:maxFileNameAndLineSize-(len(m.File)+1+lineNumSize)])
+	if fileNameSize+1+lineNumSize < maxFileNameAndLineSize {
+		buf.Write(spaces[:maxFileNameAndLineSize-(fileNameSize+1+lineNumSize)])
 	}
 
 	buf.WriteString(" (")

--- a/internal/logsink/logsink.go
+++ b/internal/logsink/logsink.go
@@ -301,11 +301,12 @@ func twoDigits(buf *bytes.Buffer, d int) {
 }
 
 func numDigits(d uint64) int {
-	if d == 0 {
+	if d < 10 {
 		return 1
 	}
-	n := 0
-	for d > 0 {
+
+	n := 1
+	for d > 9 {
 		d /= 10
 		n++
 	}

--- a/internal/logsink/logsink.go
+++ b/internal/logsink/logsink.go
@@ -203,14 +203,14 @@ func textPrintf(m *Meta, textSinks []Text, format string, args ...any) (n int, e
 	//
 	// Avoid Fprintf, for speed. The format is so simple that we can do it quickly by hand.
 	// It's worth about 3X. Fprintf is hard.
-	severityVal:= [] string{"INFO","WARN","ERROR","FATAL"}
+	severityVal := []string{"INFO", "WARN", "ERROR", "FATAL"}
 	buf.WriteByte('[')
 	buf.WriteString(severityVal[m.Severity])
 	buf.WriteString("] ")
 
 	year, month, day := m.Time.Date()
 	hour, minute, second := m.Time.Clock()
-	nDigits(buf,4,uint64(year),' ')
+	nDigits(buf, 4, uint64(year), ' ')
 	buf.WriteByte('-')
 	twoDigits(buf, int(month))
 	buf.WriteByte('-')
@@ -225,12 +225,19 @@ func textPrintf(m *Meta, textSinks []Text, format string, args ...any) (n int, e
 	nDigits(buf, 3, uint64(m.Time.Nanosecond()/1000000), '0')
 	buf.WriteByte(' ')
 
+	lineNumSize := numDigits(uint64(m.Line))
+	allowedFileNameSize := maxFileNameAndLineSize - lineNumSize - 1 // -1 for colon
+
 	{
 		file := m.File
 		if i := strings.LastIndex(file, "/"); i >= 0 {
 			file = file[i+1:]
 		}
-		buf.WriteString(file)
+		if len(file) > allowedFileNameSize {
+			buf.WriteString(file[:allowedFileNameSize])
+		} else {
+			buf.WriteString(file)
+		}
 	}
 
 	buf.WriteByte(':')
@@ -238,6 +245,10 @@ func textPrintf(m *Meta, textSinks []Text, format string, args ...any) (n int, e
 		var tmp [19]byte
 		buf.Write(strconv.AppendInt(tmp[:0], int64(m.Line), 10))
 	}
+	if len(m.File)+1+lineNumSize < maxFileNameAndLineSize {
+		buf.Write(spaces[:maxFileNameAndLineSize-(len(m.File)+1+lineNumSize)])
+	}
+
 	buf.WriteString(" (")
 	nDigits(buf, 7, uint64(m.Thread), ' ')
 	buf.WriteString(") ")
@@ -276,10 +287,26 @@ func textPrintf(m *Meta, textSinks []Text, format string, args ...any) (n int, e
 
 const digits = "0123456789"
 
+const maxFileNameAndLineSize = 26
+
+var spaces = []byte("                          ") // 26 spaces
+
 // twoDigits formats a zero-prefixed two-digit integer to buf.
 func twoDigits(buf *bytes.Buffer, d int) {
 	buf.WriteByte(digits[(d/10)%10])
 	buf.WriteByte(digits[d%10])
+}
+
+func numDigits(d uint64) int {
+	if d == 0 {
+		return 1
+	}
+	n := 0
+	for d > 0 {
+		d /= 10
+		n++
+	}
+	return n
 }
 
 // nDigits formats an n-digit integer to buf, padding with pad on the left. It

--- a/internal/logsink/logsink_test.go
+++ b/internal/logsink/logsink_test.go
@@ -1,0 +1,34 @@
+package logsink
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNumDigits(t *testing.T) {
+	cases := []struct {
+		in  uint64
+		num int
+	}{
+		{0, 1},
+		{1, 1},
+		{2, 1},
+		{3, 1},
+		{8, 1},
+		{9, 1},
+		{10, 2},
+		{11, 2},
+		{99, 2},
+		{100, 3},
+		{101, 3},
+		{234567, 6},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%d-%d", tc.in, tc.num), func(t *testing.T) {
+			if got := numDigits(tc.in); got != tc.num {
+				t.Errorf("numDigits(%d) = %d; want %d", tc.in, got, tc.num)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We, at least I, still look at log lines with my eyes 🤯 and right now they're hard to read due to the inconsistent sizing of the files and line numbers

```
[WARN] 2025-08-24T17:05:25.480 dimensions.go:238 (2642286) [background] ...
[WARN] 2025-08-24T17:05:25.481 dimensions.go:238 (2642286) [background] ...
[INFO] 2025-08-24T17:05:55.217 register_kv.go:140 (2642286) [background] ...
[WARN] 2025-08-24T17:05:55.494 dimensions.go:238 (2642286) [background] ...
[WARN] 2025-08-24T17:05:55.494 dimensions.go:238 (2642286) [background] ...
[INFO] 2025-08-24T17:06:02.443 wrappers.gen.go:2284 (2642286) [int_0f5cdbdf_5d10_4d39_973a_b6252ab7a0a7] ...
[INFO] 2025-08-24T17:06:02.443 logger.go:65 (2642286) [int_0f5cdbdf_5d10_4d39_973a_b6252ab7a0a7] ...
[INFO] 2025-08-24T17:06:02.458 wrappers.gen.go:2284 (2642286) [int_e5bc60b5_b431_44ba_b704_561b1f315d18] ...
[INFO] 2025-08-24T17:06:02.459 logger.go:65 (2642286) [int_e5bc60b5_b431_44ba_b704_561b1f315d18] ...
[INFO] 2025-08-24T17:06:02.473 wrappers.gen.go:2284 (2642286) [int_dc12f868_f823_4a51_9e1d_949aecc8ea48] ...
[INFO] 2025-08-24T17:06:02.474 logger.go:65 (2642286) [int_dc12f868_f823_4a51_9e1d_949aecc8ea48] ...
```
in our case the PID will always be the same, it's just the filename that is different so I'm limiting it here to 26 chars:
* first 20 of the filename, right padded with spaces
* :
* 5 for the line number, left padded

so it looks like this, for different file sizes
```
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 a.go:123                   (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 aaaaaaaaaaaaaaaaaaaaaaa.:1 (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 abcdefghijklmnopqrstuvw:12 (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 abcdefghijklmnopqrstu:1234 (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 abcdefghijklmnopqrst:12345 (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 abcdefghijklmnopqrs:123456 (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 abcdefghijklmnopqrs:123456 (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 abcdefghijklmnopqr:1234567 (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 short.go:1                 (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 short.go:12                (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 short.go:1234              (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 short.go:12345             (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 short.go:123456            (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 short.go:123456            (       )
2025/08/25 10:17:28 [INFO]    1-01-01T00:00:00.000 short.go:1234567           (       )
```

What about the INFO, WARN, doesn't it also do ERROR which is 5 chars and not 4? yes.... Not sure what that impact to consumers would be if I change that to `ERRO`